### PR TITLE
Addd mkcert and make chrome trust https URLs, fixes #15

### DIFF
--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -4,6 +4,16 @@
 #
 # This file comes from https://github.com/drud/ddev-selenium-standalone-chrome
 #
+hooks:
+  # Make sure that the standard mkcert CA keys are readable
+  # as they normally are owned by the ddev-defined user, and here we're running
+  # as 'seluser'
+  # and do a mkcert -install so we can trust them
+  post-start:
+    - exec: "sudo chmod ugo+r /mnt/ddev-global-cache/mkcert/*"
+    - exec: "mkcert -install"
+      service: selenium-chrome
+
 web_environment:
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -7,7 +7,7 @@
 version: '3.6'
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:4.1.4-20220429
+    build: selenium-standalone-chrome
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed
@@ -27,6 +27,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
     volumes:
       - ".:/mnt/ddev_config"
+      - ddev-global-cache:/mnt/ddev-global-cache
 
   web:
     links:

--- a/install.yaml
+++ b/install.yaml
@@ -3,6 +3,7 @@ pre_install_actions:
 project_files:
 - docker-compose.selenium-chrome.yaml
 - config.selenium-standalone-chrome.yaml
+- selenium-standalone-chrome/Dockerfile
 global_files:
 post_install_actions:
 yaml_read_files:

--- a/selenium-standalone-chrome/Dockerfile
+++ b/selenium-standalone-chrome/Dockerfile
@@ -1,0 +1,10 @@
+#ddev-generated
+
+FROM seleniarm/standalone-chromium:4.1.4-20220429
+ENV CAROOT=/mnt/ddev-global-cache/mkcert
+
+USER root
+RUN apt update >/dev/null && apt install -y iputils-ping less mkcert vim >/dev/null
+RUN usermod -s /bin/bash seluser
+USER seluser
+RUN echo "capath=/etc/ssl/certs/" >>~/.curlrc

--- a/selenium-standalone-chrome/Dockerfile
+++ b/selenium-standalone-chrome/Dockerfile
@@ -4,7 +4,7 @@ FROM seleniarm/standalone-chromium:4.1.4-20220429
 ENV CAROOT=/mnt/ddev-global-cache/mkcert
 
 USER root
-RUN apt update >/dev/null && apt install -y iputils-ping less mkcert vim >/dev/null
+RUN apt update >/dev/null && apt install -y iputils-ping less mkcert procps vim >/dev/null
 RUN usermod -s /bin/bash seluser
 USER seluser
 RUN echo "capath=/etc/ssl/certs/" >>~/.curlrc


### PR DESCRIPTION
#15 points out that https URLs aren't trusted by chrome here.

This installs mkcert in the chrome container and makes it trust the shared mkcert CA.
curl also works inside the chrome container.

You can test this PR with 

`ddev get https://github.com/rfay/ddev-selenium-standalone-chrome/tarball/20230121_trust_certs`

This seems to demonstrate that the [demonstration repo](https://github.com/ptmkenny/d10-behat) provided by @ptmkenny in #15 will work OK, trusting https URLs. 