### PR TITLE
clarify how to enable VNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If you want to use the browser provided by this addon to check out the test resu
 
 You can now connect to [DDEV SITE URL]:5900 (password: `secret`) in your VNC client.
 
+Note that when using `ports`, only one project at a time can be running with port 5900.
+
 ## Contribute
 
 - Anyone is welcome to submit a PR to this repo. See README.md at https://github.com/drud/ddev-addon-template, the parent of this repo.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,30 @@ This service can be used with any project type. The examples below are Drupal-sp
   - Drupal Test Traits
     - Ensure you have a working site that has the `weitzman/drupal-test-traits` Composer package.
     - `ddev exec -d /var/www/html/web "../vendor/bin/phpunit --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --printer '\Drupal\Tests\Listeners\HtmlOutputPrinter' ../vendor/weitzman/drupal-test-traits/tests/ExampleSelenium2DriverTest.php"`
-- On your host, browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run (neat!).
+
+## Watching the tests
+
+### The easy way: Use noVNC (built-in)
+
+On your host, browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
+
+This is a no-configuration solution that enables you to quickly see what is going on with your tests.
+
+### Use a local VNC client (try noVNC first!)
+
+If you are using something like behat and want to debug tests when they fail by manually navigating around your site in the Chromium browser included with this addon, you might want to use a VNC client installed on your machine, such as Screen Sharing on macOS (built-in) or TightVNC on Linux and Windows (must be downloaded and installed). This is because with noVNC, you are running a browser (Chromium) inside another browser (whatever browser you use on your local machine), which can be inconvenient-- for example, the keyboard shortcut to reload a page in Chromium will reload your local browser and kick you out of noVNC instead of reloading Chromium, and it may be hard to type a new url in the Chromium address bar due to how your local browser handles keyboard input.
+
+In other words, if you just want to watch the tests, use noVNC.
+
+If you want to use the browser provided by this addon to check out the test results by poking around your site, consider using a local VNC client. To do so, you need to open port 5900.
+
+#### How to open port 5900 for VNC access
+
+1. Open `.ddev/docker-compose.selenium-chrome.yaml`.
+2. Uncomment the two lines about `ports` and `5900:5900`.
+3. Execute `ddev restart`.
+
+You can now connect to [DDEV SITE URL]:5900 (password: `secret`) in your VNC client.
 
 ## Contribute
 

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -19,9 +19,10 @@ services:
       - HTTP_EXPOSE=7910:7900
     external_links:
       - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
-      #ports:
-      # VNC access for a traditional VNC client like macOS "Screen Sharing".
-      # - "5900:5900"
+    # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",
+    # uncomment the following two lines.
+    #ports:
+    #  - "5900:5900"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
This may be a rookie mistake, but I had trouble enabling VNC because I uncommented the "5900:5900" line and missed uncommenting "ports:".  Another reason I missed this is that the indentation is wrong; "ports:" has to be at the level of "external_links".  So I edited the comment to make it more clear about how to enable port 5900.