### PR TITLE
🚚 move to `ddev` domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,15 +53,15 @@ jobs:
 
     - name: Use ddev stable
       if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'
@@ -71,7 +71,7 @@ jobs:
         mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
 
     - name: Download docker images
-      run: | 
+      run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
         docker pull memcached:1.6 >/dev/null
     - name: tmate debugging session
@@ -109,5 +109,3 @@ jobs:
     # GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v1
       if: matrix.ddev_version == 'stable'
-
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/drud/ddev-selenium-standalone-chrome/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-selenium-standalone-chrome/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## Introduction
 
@@ -6,10 +6,10 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 ## Install/Update
 
-1. `ddev get drud/ddev-selenium-standalone-chrome`
+1. `ddev get ddev/ddev-selenium-standalone-chrome`
 2. Optional. Update the provided .ddev/config.selenium-standalone-chrome.yaml as you see fit(and remove the #ddev-generated line). You can also just override lines in your .ddev/config.yaml
 3. Optional. Check config.selenium-standalone-chrome.yaml and docker-compose.selenium-chrome.yaml into your source control.
-4. Update by re-running `ddev get drud/ddev-selenium-standalone-chrome`.
+4. Update by re-running `ddev get ddev/ddev-selenium-standalone-chrome`.
 
 ## Use
 
@@ -28,7 +28,7 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 ## Contribute
 
-- Anyone is welcome to submit a PR to this repo. See README.md at https://github.com/drud/ddev-addon-template, the parent of this repo.
+- Anyone is welcome to submit a PR to this repo. See README.md at https://github.com/ddev/ddev-addon-template, the parent of this repo.
 
 ## Maintainer
 

--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -1,8 +1,8 @@
 #ddev-generated
 # Remove the line above if you don't want this file to be overwritten when you run
-# ddev get drud/ddev-selenium-standalone-chrome
+# ddev get ddev/ddev-selenium-standalone-chrome
 #
-# This file comes from https://github.com/drud/ddev-selenium-standalone-chrome
+# This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
 web_environment:
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -1,8 +1,8 @@
 #ddev-generated
 # Remove the line above if you don't want this file to be overwritten when you run
-# ddev get drud/ddev-selenium-standalone-chrome
+# ddev get ddev/ddev-selenium-standalone-chrome
 #
-# This file comes from https://github.com/drud/ddev-selenium-standalone-chrome
+# This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
 version: '3.6'
 services:


### PR DESCRIPTION
This PR updates docs and tests for the move to `ddev` domain.