### PR TITLE
Adds config edit step to noVNC instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 ### The easy way: Use noVNC (built-in)
 
-On your host, browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
+1. In your project's _.ddev/config.selenium-standalone-chrome.yaml_, on the line that sets arguments for `MINK_DRIVER_ARGS_WEBDRIVER`, delete `\"--headless\",`, to enable the tests to run in the browser (not in headless mode).
+2. On your host, browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
 
-This is a no-configuration solution that enables you to quickly see what is going on with your tests.
+This enables you to quickly see what is going on with your tests.
 
 ### Use a local VNC client (try noVNC first!)
 


### PR DESCRIPTION
By default, this service runs in headless mode. As far as I could figure out, you can't actually see the tests run in a browser using noVNC unless you remove the --headless option from MINK_DRIVER_ARGS_WEBDRIVER in config.selenium-standalone-chrome.yaml. This PR adds a step in the instructions about noVNC to edit config and remove the headless option so that you can see the tests run via the noVNC port 7900.