### PR TITLE
add example Behat

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ You can now connect to [DDEV SITE URL]:5900 (password: `secret`) in your VNC cli
 
 Note that when using `ports`, only one project at a time can be running with port 5900.
 
+### Behat config example
+
+If you use Behat as a test running, adjust your `behat.yml`
+
+```yml
+  extensions:
+    Behat\MinkExtension:
+      base_url: http://web
+      selenium2:
+        wd_host: http://selenium-chrome:4444/wd/hub
+        capabilities:
+          chrome:
+            switches:
+              - "--disable-gpu"
+              - "--headless"
+              - "--no-sandbox"
+              - "--disable-dev-shm-usage"
+```
+
 ## Contribute
 
 - Anyone is welcome to submit a PR to this repo. See README.md at https://github.com/ddev/ddev-addon-template, the parent of this repo.


### PR DESCRIPTION
Fixes #21

This PR adds an example snippet for using this addon with Drupal and Behat.

I kept the `base_url` as `http` to match the environmental variables you have set in `config.selenium-standalone-chrome.yaml`

If `base_url` is set to `https://web`, an additional switch is required: `- "--ignore-certificate-errors"`.

## Tested

- Works as`Behat\MinkExtension` extension
- Works when changing to `Drupal\MinkExtension` extension
- Comment out `- "--headless"` to watch in noVNC

Note: if I commented out the `capabilities` section, Behat freezes. It didn't seem to matter what switches I used, as long as it was there.
