### PR TITLE
Add DRUPAL_TEST_WEBDRIVER_CHROME_ARGS for Nightwatch tests with login

### DIFF
--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -19,6 +19,7 @@ web_environment:
   - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
   - DRUPAL_TEST_WEBDRIVER_PORT=4444
   - DRUPAL_TEST_WEBDRIVER_PATH_PREFIX=/wd/hub
+  - DRUPAL_TEST_WEBDRIVER_CHROME_ARGS=--disable-gpu --headless --no-sandbox --disable-dev-shm-usage
   - DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false
   - DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY=../
   - DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -35,6 +35,8 @@ teardown() {
   ddev exec -d /var/www/html/web/core yarn install
   ddev exec -d /var/www/html/web/core touch .env
   ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js
+  echo "Run a Nightwatch test that logs into Drupal." >&3
+  ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
   echo "Install Drupal and run a DTT test." >&3
   ddev exec -d /var/www/html/web "../vendor/bin/drush si -y --account-name=admin --account-pass=password standard"
   ddev exec -d /var/www/html/web "../vendor/bin/phpunit --log-junit dtt.junit.xml --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --printer '\Drupal\Tests\Listeners\HtmlOutputPrinter' ../vendor/weitzman/drupal-test-traits/tests/ExampleSelenium2DriverTest.php"


### PR DESCRIPTION
Edit: tl;dr Please see the test results, where Drupal core's `tests/Drupal/Nightwatch/Tests/loginTest.js` fails to run against the main branch but passes with the additional configuration in place.

I followed the Nightwatch setup steps in the README.

What I'm seeing is Nightwatch tests that log in to Drupal fail to execute. After I add the following line to `.ddev/config.selenium-standalone-chrome.yaml` and run `ddev start`, these tests run smoothly.

```yaml
- DRUPAL_TEST_WEBDRIVER_CHROME_ARGS=--disable-gpu --headless --no-sandbox --disable-dev-shm-usage
```

For example, run:
```
ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
```

Log output (before making this change):

```
❯ ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
yarn run v1.22.19
$ cross-env BABEL_ENV=development node -r dotenv-safe/config -r @babel/register ./node_modules/.bin/nightwatch --config ./tests/Drupal/Nightwatch/nightwatch.conf.js tests/Drupal/Nightwatch/Tests/loginTest.js

[Tests/Login Test] Test Suite
=============================
ℹ Connected to selenium-chrome on port 4444 (885ms).
  Using: chrome (101.0.4951.41) on LINUX platform.

⚠ Running Test login:

✖ Expected element <.user-role-form .machine-name-value> to be visible in 2000ms - element was not found - expected "visible" but got: "not found" (2161ms)
    at Object.call (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalCreateRole.js:28:15)
    at Object.drupalLoginAsAdmin (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalLoginAsAdmin.js:35:14)
    at processImmediate (node:internal/timers:466:21)

 Error while running .getScreenshot() protocol action: An unknown server-side error occurred while processing the command. – unknown error: cannot activate web view

 Couldn't save screenshot to "/var/www/html/web/core/reports/nightwatch/screenshots/Tests/loginTest/Test-login_FAILED_Mar-13-2023-162425-GMT+0000.png":
   Error: An unknown server-side error occurred while processing the command. – unknown error: cannot activate web view
       at processTicksAndRejections (node:internal/process/task_queues:96:5)

FAILED: 1 assertions failed (4.594s)
_________________________________________________

TEST FAILURE:  1 assertions failed, 0 passed (8.367s)

 ✖ Tests/loginTest
 – Test login (4.594s)
   Expected element <.user-role-form .machine-name-value> to be visible in 2000ms - element was not found - expected "visible" but got: "not found" (2161ms)
       at Object.call (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalCreateRole.js:28:15)
       at Object.drupalLoginAsAdmin (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalLoginAsAdmin.js:35:14)
       at processImmediate (node:internal/timers:466:21)

error Command failed with exit code 5.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

And this different log message that I got at another point while testing:

```
❯ ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
yarn run v1.22.19
$ cross-env BABEL_ENV=development node -r dotenv-safe/config -r @babel/register ./node_modules/.bin/nightwatch --config ./tests/Drupal/Nightwatch/nightwatch.conf.js tests/Drupal/Nightwatch/Tests/loginTest.js

[Tests/Login Test] Test Suite
=============================
ℹ Connected to selenium-chrome on port 4444 (2054ms).
  Using: chrome (101.0.4951.41) on LINUX platform.

⠋ Running Test login:
   NoSuchElementError: An error occurred while running .setValue() command on <input[name="label"]>:
   {"sessionId":"379f17b3f08d7edf7a2f89879c67635f","status":0,"value":[]}
       at Object.call (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalCreateRole.js:25:8)
       at Object.drupalLoginAsAdmin (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalLoginAsAdmin.js:35:14)
⚠ Running Test login:

✖ Expected element <.user-role-form .machine-name-value> to be visible in 2000ms - element was not found - expected "visible" but got: "not found" (2177ms)
    at Object.call (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalCreateRole.js:28:15)
    at Object.drupalLoginAsAdmin (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalLoginAsAdmin.js:35:14)
    at processImmediate (node:internal/timers:466:21)


FAILED: 1 assertions failed and  2 errors (10.028s)
_________________________________________________

TEST FAILURE: 2 errors during execution; 1 assertions failed, 0 passed (15.37s)

 ✖ Tests/loginTest
 – Test login (10.028s)
   Expected element <.user-role-form .machine-name-value> to be visible in 2000ms - element was not found - expected "visible" but got: "not found" (2177ms)
       at Object.call (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalCreateRole.js:28:15)
       at Object.drupalLoginAsAdmin (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalLoginAsAdmin.js:35:14)
       at processImmediate (node:internal/timers:466:21)

  NoSuchElementError: An error occurred while running .setValue() command on <input[name="label"]>:
   {"sessionId":"379f17b3f08d7edf7a2f89879c67635f","status":0,"value":[]}
       at Object.call (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalCreateRole.js:25:8)
       at Object.drupalLoginAsAdmin (/var/www/html/web/core/tests/Drupal/Nightwatch/Commands/drupalLoginAsAdmin.js:35:14)
       at processImmediate (node:internal/timers:466:21)


  Error: Error while running "perform" command: Timeout while waiting (10000ms) for the .perform() command callback to be called.
       at listOnTimeout (node:internal/timers:559:17)
       at processTimers (node:internal/timers:502:7)


error Command failed with exit code 5.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Finally, log with the changes in place:
```
❯ ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
yarn run v1.22.19
$ cross-env BABEL_ENV=development node -r dotenv-safe/config -r @babel/register ./node_modules/.bin/nightwatch --config ./tests/Drupal/Nightwatch/nightwatch.conf.js tests/Drupal/Nightwatch/Tests/loginTest.js

[Tests/Login Test] Test Suite
=============================
ℹ Connected to selenium-chrome on port 4444 (365ms).
  Using: chrome (101.0.4951.41) on LINUX platform.

✔ Running Test login:

✔ Expected element <.user-role-form .machine-name-value> to be visible in 2000ms (602ms)
✔ User "user" was created successfully (70ms)
✔ Passed [equal]: The user "user" was logged in.
✔ Element <body> was visible after 51 milliseconds.
✔ Testing if element <h1> contains text 'Reports' (71ms)
✔ Ensuring no deprecation errors have been triggered (24ms)

OK. 6 assertions passed. (8.195s)
Done in 24.03s.
```

---

See also:

```
ddev exec -d /var/www/html/web/core yarn test:nightwatch modules/toolbar/tests/src/Nightwatch/Tests/toolbarTest.js
```

Or (as far as I can tell) any tests that call `drupalLoginAsAdmin()` or `drupalLogin()`.

I believe my ddev setup is fairly standard. I ran `ddev config` and nothing changed:

```yaml
name: d9sandbox
type: drupal9
docroot: web
php_version: "8.1"
webserver_type: nginx-fpm
router_http_port: "80"
router_https_port: "443"
xdebug_enabled: false
additional_hostnames: []
additional_fqdns: []
database:
  type: mariadb
  version: "10.3"
nfs_mount_enabled: false
mutagen_enabled: false
use_dns_when_possible: true
composer_version: "2"
web_environment:
  - SIMPLETEST_BASE_URL=http://ddev-d9sandbox-web
  - REDIS_HOST=redis
nodejs_version: "16"
```