### PR TITLE
Fix addon name

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: addon-template
+name: ddev-selenium-standalone-chrome
 pre_install_actions:
 project_files:
 - docker-compose.selenium-chrome.yaml


### PR DESCRIPTION
This PR fixes the name of the addon when using `ddev get --installed`.

Currently, it displays as "addon-template" (see screenshot)

![ddev-installed-addons](https://github.com/ddev/ddev-selenium-standalone-chrome/assets/7234392/64e7385f-bd20-49e1-98ae-23386cd3602c)

! `--installed` is a new feature in https://github.com/ddev/ddev/pull/4891.


