### PR TITLE
Use updated seleniarm docker image

### DIFF
--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -7,7 +7,7 @@
 version: '3.6'
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:latest
+    image: seleniarm/standalone-chromium:117.0
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -7,7 +7,7 @@
 version: '3.6'
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:117.0
+    image: 'seleniarm/standalone-chromium:117.0'
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -7,7 +7,7 @@
 version: '3.6'
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:4.1.4-20220429
+    image: seleniarm/standalone-chromium:latest
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed


### PR DESCRIPTION
## The Issue

The Docker Composer file is pinned against a really old version of the seleniarm image.

To do: update documentation regarding Docker image version.

## How This PR Solves The Issue

Updates the tag for the image to `latest`, and users can pin to a specific version if desired.

## Manual Testing Instructions

Update `docker-compose.selenium-chrome.yaml` in an existing project to use the `latest` tag and run `ddev poweroff && ddev start`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

