### PR TITLE
Add header in README.md, and add `ddev restart` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![tests](https://github.com/ddev/ddev-selenium-standalone-chrome/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
+# DDEV Selenium Standalone Chrome
+
 ## Introduction
 
 This service can be used with any project type. The examples below are Drupal-specific. Contributions for docs and tests that show this service working with other project types are appreciated.
@@ -7,9 +9,10 @@ This service can be used with any project type. The examples below are Drupal-sp
 ## Install/Update
 
 1. `ddev get ddev/ddev-selenium-standalone-chrome`
-2. Optional. Update the provided .ddev/config.selenium-standalone-chrome.yaml as you see fit(and remove the #ddev-generated line). You can also just override lines in your .ddev/config.yaml
-3. Optional. Check config.selenium-standalone-chrome.yaml and docker-compose.selenium-chrome.yaml into your source control.
-4. Update by re-running `ddev get ddev/ddev-selenium-standalone-chrome`.
+2. `ddev restart`
+3. Optional. Update the provided .ddev/config.selenium-standalone-chrome.yaml as you see fit(and remove the #ddev-generated line). You can also just override lines in your .ddev/config.yaml
+4. Optional. Check config.selenium-standalone-chrome.yaml and docker-compose.selenium-chrome.yaml into your source control.
+5. Update by re-running `ddev get ddev/ddev-selenium-standalone-chrome`.
 
 ## Use
 


### PR DESCRIPTION
This is awesome, thanks! It's great that something with so many moving parts and manual configuration can be easily installed and just works.

I do think that emphasizing that a restart is required would be great. I installed it and got an error when I immediately after that tried running a test, and just got an error.

Also, a header would be nice.

## The Issue

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

