### PR TITLE
Use https by default during tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 ### The easy way: Use noVNC (built-in)
 
-1. Remove --headless from the MINK_DRIVER_ARGS_WEBDRIVER in your project's .ddev/config.selenium-standalone-chrome.yaml. Run `ddev restart`.  
+1. Remove --headless from the MINK_DRIVER_ARGS_WEBDRIVER (or DTT_MINK_DRIVER_ARGS if using DTT) or in your project's .ddev/config.selenium-standalone-chrome.yaml. Run `ddev restart`.  
 2. On your host, browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
 
 This enables you to quickly see what is going on with your tests.
@@ -62,7 +62,7 @@ If you use Behat as a test running, adjust your `behat.yml`
 ```yml
   extensions:
     Behat\MinkExtension:
-      base_url: http://web
+      base_url: https://web
       selenium2:
         wd_host: http://selenium-chrome:4444/wd/hub
         capabilities:
@@ -70,8 +70,9 @@ If you use Behat as a test running, adjust your `behat.yml`
             switches:
               - "--disable-gpu"
               - "--headless"
-              - "--no-sandbox"
               - "--disable-dev-shm-usage"
+              - "--no-sandbox"
+              - "--ignore-certificate-errors"
 ```
 
 ## Contribute

--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -7,14 +7,14 @@
 web_environment:
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
-  - SIMPLETEST_BASE_URL=http://web
+  - SIMPLETEST_BASE_URL=https://web
   - SIMPLETEST_DB=mysql://db:db@db/db
   # Use disable-dev-shm-usage instead of setting shm_usage
   # https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
   # The format of chromeOptions is defined at https://chromedriver.chromium.org/capabilities
-  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\", \"--ignore-certificate-errors\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
   # Nightwatch
-  - DRUPAL_TEST_BASE_URL=http://web
+  - DRUPAL_TEST_BASE_URL=https://web
   - DRUPAL_TEST_DB_URL=mysql://db:db@db/db
   - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
   - DRUPAL_TEST_WEBDRIVER_PORT=4444
@@ -25,5 +25,5 @@ web_environment:
   - DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
   - DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
   # DTT
-  - DTT_BASE_URL=http://web
-  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  - DTT_BASE_URL=https://web
+  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\", \"--ignore-certificate-errors\"]}}, \"http://selenium-chrome:4444/wd/hub\"]


### PR DESCRIPTION
For better compat with end user requests, we use https by default when configuring selenium-chrome.

I could see this breaking some tests that assert on full URLs. Thats arguably a but so unsure if I will do a major version bump. Feedback welcome.