### PR TITLE
remove obsolete "version"

### DIFF
--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -4,7 +4,6 @@
 #
 # This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
-version: '3.6'
 services:
   selenium-chrome:
     image: seleniarm/standalone-chromium:4.1.4-20220429


### PR DESCRIPTION
This PR removes the `version` key from docker-compose file.

This removes the stops the following warning from being displayed:

```shell
$ ddev start
...
time="2024-03-25T13:30:20+09:00" level=warning msg="/home/user13/banana/.ddev/docker-compose.selenium-chrome.yaml: `version` is obsolete" 
```