### PR TITLE
Update selenium image to 124.0

### DIFF
--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -6,7 +6,7 @@
 #
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:4.1.4-20220429
+    image: seleniarm/standalone-chromium:124.0
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed


### PR DESCRIPTION
## The Issue

The plugin uses a selenium docker image, which is about two years old and contains outdated Chromium version 101

## How This PR Solves The Issue

This PR switches to a newer docker image with Chromium version 124. I also thought about using "latest" instead of a specific version. But I decided against it, because this would mean, the users always would use and pull new images with other Chromium versions which would result in unexpected behavior.

## Manual Testing Instructions

Update the current plugin in your DDEV settings and execute `ddev restart`. This will trigger to pull the newer image.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

