### PR TITLE
DOCS: add launch by port

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This service can be used with any project type. The examples below are Drupal-sp
 ### The easy way: Use noVNC (built-in)
 
 1. Remove --headless from the MINK_DRIVER_ARGS_WEBDRIVER in your project's .ddev/config.selenium-standalone-chrome.yaml. Run `ddev restart`.  
-2. On your host, browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
+2. On your host, run `ddev launch :7900` or browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
 
 This enables you to quickly see what is going on with your tests.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 ### The easy way: Use noVNC (built-in)
 
-1. Remove --headless from the MINK_DRIVER_ARGS_WEBDRIVER in your project's .ddev/config.selenium-standalone-chrome.yaml. Run `ddev restart`.  
+1. Remove --headless from the MINK_DRIVER_ARGS_WEBDRIVER in your project's .ddev/config.selenium-standalone-chrome.yaml. Run `ddev restart`.
 2. On your host, run `ddev launch :7900` or browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
 
 This enables you to quickly see what is going on with your tests.


### PR DESCRIPTION
## The Issue

## How This PR Solves The Issue

This update the docs for the new "accept port in ddev launch" feature.

Developers can now type: `ddev launch :7900` to open the noVNC page.

The old "browse to" command was left in for people on older versions of DDEV. Happy to remove it if you want.

## Manual Testing Instructions

Follow instructions under "The easy way: Use noVNC (built-in)", and use the `ddev launch :7900` command.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

https://github.com/ddev/ddev/pull/6024

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

