### PR TITLE
Make VNC connection without password by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ This service can be used with any project type. The examples below are Drupal-sp
 ### The easy way: Use noVNC (built-in)
 
 1. Remove --headless from the MINK_DRIVER_ARGS_WEBDRIVER in your project's .ddev/config.selenium-standalone-chrome.yaml. Run `ddev restart`.
-2. On your host, run `ddev launch :7900` or browse to https://[DDEV SITE URL]:7900 (password: `secret`) to watch tests run with noVNC (neat!).
+2. On your host, run `ddev launch :7900` or browse to https://[DDEV SITE URL]:7900 to watch tests run with noVNC (neat!).
+
+By default noVNC connects without password, you can enable password by removing the "VNC_NO_PASSWORD=1" line in the file `docker-compose.selenium-chrome.yaml`, the default password will be `secret`, and you can set the custom one via `VNC_PASSWORD` environment variable.
 
 This enables you to quickly see what is going on with your tests.
 

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -16,6 +16,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTPS_EXPOSE=7900:7900
       - HTTP_EXPOSE=7910:7900
+      - VNC_NO_PASSWORD=1
     external_links:
       - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
     # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",


### PR DESCRIPTION
## The Issue
Now we have to type the `secret` password each time when connecting. But ddev usually runs locally on local machines, so there is no sense in protecting it by password, especially with the well-known one.

Also, it pretty often gets stuck, so I have to restart the container many times per day, and then - reconnect noVNC again with typing the password.

So, I vote for making the VNC connection without a password by default.

## How This PR Solves The Issue
Allows connection without any password by default.


## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

VNC connection does not require the `secret` password and connects automatically without any password.

