### PR TITLE
fix: add support for multiple hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Then restart your project
 ddev restart
 ```
 
+> [!NOTE]
+> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get ddev/ddev-selenium-standalone-chrome`
+
 ### Optional steps
 
 1. Update the provided `.ddev/config.selenium-standalone-chrome.yaml` as you see fit (and remove the #ddev-generated line). You can also just override lines in your `.ddev/config.yaml`

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -17,8 +17,6 @@ services:
       - HTTPS_EXPOSE=7900:7900
       - HTTP_EXPOSE=7910:7900
       - VNC_NO_PASSWORD=1
-    external_links:
-      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
     # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",
     # uncomment the following two lines.
     #ports:

--- a/install.yaml
+++ b/install.yaml
@@ -1,8 +1,38 @@
 name: ddev-selenium-standalone-chrome
-pre_install_actions:
+
 project_files:
 - docker-compose.selenium-chrome.yaml
 - config.selenium-standalone-chrome.yaml
-global_files:
+
 post_install_actions:
-yaml_read_files:
+  - |
+    #ddev-nodisplay
+    #ddev-description:Checking docker-compose.selenium-chrome_extras.yaml for changes
+    if [ -f docker-compose.selenium-chrome_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.selenium-chrome_extras.yaml; then
+      echo "Existing docker-compose.selenium-chrome_extras.yaml does not have #ddev-generated, so can't be updated"
+      exit 2
+    fi
+  - |
+    #ddev-nodisplay
+    #ddev-description:Adding all hostnames to the selenium-chrome container to make them available
+    cat <<-END >docker-compose.selenium-chrome_extras.yaml
+    #ddev-generated
+    services:
+      selenium-chrome:
+        external_links:
+        {{- $selenium_chrome_hostnames := splitList "," (env "DDEV_HOSTNAME") -}}
+        {{- range $i, $n := $selenium_chrome_hostnames }}
+          - "ddev-router:{{- replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) -}}"
+        {{- end }}
+    END
+removal_actions:
+  - |
+    #ddev-nodisplay
+    #ddev-description:Remove docker-compose.selenium-chrome_extras.yaml file
+    if [ -f docker-compose.selenium-chrome_extras.yaml ]; then
+      if grep -q '#ddev-generated' docker-compose.selenium-chrome_extras.yaml; then
+        rm -f docker-compose.selenium-chrome_extras.yaml
+      else
+        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/docker-compose.selenium-chrome_extras.yaml' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi


### PR DESCRIPTION
## The Issue

- Closes #52

`extrernal_links` don't work properly when you have `additional_hostnames` or `additional_fqdns`.

https://github.com/ddev/ddev-selenium-standalone-chrome/blob/d11aaf3bb359b1fbb25b29a0d5afc9bdc0642098/docker-compose.selenium-chrome.yaml#L20-L21

```yaml
 external_links: 
   - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
```

It works only for the main URL, but not for additional URLs.

## How This PR Solves The Issue

Uses go templates to create the correct `external_links` in `.ddev/docker-compose.selenium-chrome_extras.yaml`

## Manual Testing Instructions

This allows for example to have Mailpit to work automatically without any port change.

```
mkdir selenium-chrome-test && cd selenium-chrome-test
ddev config --additional-fqdns="hello.test" --additional-hostnames "extra1,extra2,more.extra"
echo '<?php echo "Hello World;"; ?>' > index.php
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/20250107_stasadev_external_links

cat .ddev/docker-compose.selenium-chrome_extras.yaml
#ddev-generated
services:
  selenium-chrome:
    external_links:
      - "ddev-router:${DDEV_PROJECT}.${DDEV_TLD}"
      - "ddev-router:extra1.${DDEV_TLD}"
      - "ddev-router:extra2.${DDEV_TLD}"
      - "ddev-router:hello.test"
      - "ddev-router:more.extra.${DDEV_TLD}"

ddev start

cat .ddev/.ddev-docker-compose-full.yaml
        external_links:
            - ddev-router:selenium-chrome-test.ddev.site
            - ddev-router:extra1.ddev.site
            - ddev-router:extra2.ddev.site
            - ddev-router:hello.test
            - ddev-router:more.extra.ddev.site
```

## Related Issue Link(s)

- https://github.com/tyler36/ddev-cypress/pull/54
