### PR TITLE
test: Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,21 +40,21 @@ jobs:
         addon_ref: ${{ env.GITHUB_REF }}
 
     - name: Archive browser_output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: browser_output
         path: |
           web/sites/simpletest/browser_output
 
     - name: Archive junits
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: junits
         path: |
           *.junit.xml
 
     - name: Nightwatch reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nightwatch
         path: |


### PR DESCRIPTION
## The Issue

All tests are failing because:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

(https://github.com/ddev/ddev-selenium-standalone-chrome/actions/runs/13108167597/job/36566392399)

upload-artifact has to go to v4.

## How This PR Solves The Issue

Bump it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

