### PR TITLE
test: update bats to use `ddev add-on get`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,19 +5,21 @@ on:
     branches: [ main ]
 
   schedule:
-  - cron: '01 07 * * *'
+  - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Debug with tmate set "debug_enabled"'
+        type: boolean
+        description: Debug with tmate
         required: false
-        default: "false"
+        default: false
 
-env:
-  # Allow ddev get to use a github token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
   actions: write
 
@@ -31,31 +33,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        ddev_version: ${{ matrix.ddev_version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        debug_enabled: ${{ github.event.inputs.debug_enabled }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}
 
-    - name: Archive browser_output
-      uses: actions/upload-artifact@v4
-      with:
-        name: browser_output
-        path: |
-          web/sites/simpletest/browser_output
+      - name: Archive browser_output
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser_output
+          path: |
+            web/sites/simpletest/browser_output
 
-    - name: Archive junits
-      uses: actions/upload-artifact@v4
-      with:
-        name: junits
-        path: |
-          *.junit.xml
+      - name: Archive junits
+        uses: actions/upload-artifact@v4
+        with:
+          name: junits
+          path: |
+            *.junit.xml
 
-    - name: Nightwatch reports
-      uses: actions/upload-artifact@v4
-      with:
-        name: nightwatch
-        path: |
-          web/core/reports/nightwatch
+      - name: Nightwatch reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightwatch
+          path: |
+            web/core/reports/nightwatch

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,43 +1,100 @@
+#!/usr/bin/env bats
+
+# Bats is a testing framework for Bash
+# Documentation https://bats-core.readthedocs.io/en/stable/
+# Bats libraries documentation https://github.com/ztombol/bats-docs
+
+# For local tests, install bats-core, bats-assert, bats-file, bats-support
+# And run this in the add-on root directory:
+#   bats ./tests/test.bats
+# To exclude release tests:
+#   bats ./tests/test.bats --filter-tags '!release'
+# For debugging:
+#   bats ./tests/test.bats --show-output-of-passing-tests --verbose-run --print-output-on-failure
+
 setup() {
   set -eu -o pipefail
-  export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/testchrome
-  mkdir -p $TESTDIR
-  export PROJNAME=testchrome
-  export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
+
+  # Override this variable for your add-on:
+  export GITHUB_REPO=ddev/ddev-selenium-standalone-chrome
+
+  TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+  export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
+  bats_load_library bats-assert
+  bats_load_library bats-file
+  bats_load_library bats-support
+
+  export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
+  export PROJNAME="test-$(basename "${GITHUB_REPO}")"
+  mkdir -p ~/tmp
+  export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
+  export DDEV_NONINTERACTIVE=true
+  export DDEV_NO_INSTRUMENTATION=true
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
   cd "${TESTDIR}"
+
   composer -n --no-install create-project 'drupal/recommended-project:^10' .
   composer -n config --no-plugins allow-plugins true
   composer -n require 'drupal/core-dev:^10' 'drush/drush:^12' 'phpspec/prophecy-phpunit:^2' 'weitzman/drupal-test-traits:^2'
-  ddev config --project-name=${PROJNAME} --php-version=8.1 --web-environment-add SYMFONY_DEPRECATIONS_HELPER=disabled
-  ddev start -y >/dev/null
+
+  run ddev config --project-name=${PROJNAME} --project-tld=ddev.site --php-version=8.1 --web-environment-add=SYMFONY_DEPRECATIONS_HELPER=disabled
+  assert_success
+  run ddev start -y
+  assert_success
+}
+
+health_checks() {
+  run ddev exec curl -sfI selenium-chrome:4444/wd/hub/status
+  assert_success
+  assert_output --partial "HTTP/1.1 200 OK"
+
+  run ddev exec curl -sf selenium-chrome:4444/wd/hub/status
+  assert_success
+  assert_output --partial "Selenium Grid ready."
+
+  echo "Run a FunctionalJavascript test." >&3
+
+  run ddev exec -d /var/www/html/web "../vendor/bin/phpunit -v -c ./core/phpunit.xml.dist ./core/modules/system/tests/src/FunctionalJavascript/FrameworkTest.php"
+  assert_success
+
+  echo "Run a Nightwatch test." >&3
+
+  run ddev exec -d /var/www/html/web/core yarn install
+  assert_success
+
+  run ddev exec -d /var/www/html/web/core touch .env
+  assert_success
+  assert_file_exists web/core/.env
+
+  run ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/jsOnceTest.js
+  assert_success
+
+  echo "Run a Nightwatch test that logs into Drupal." >&3
+
+  run ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
+  assert_success
+
+  echo "Install Drupal and run a DTT test." >&3
+
+  run ddev exec -d /var/www/html/web "../vendor/bin/drush si -y --account-name=admin --account-pass=password standard"
+  assert_success
+
+  run ddev exec -d /var/www/html/web "../vendor/bin/phpunit --log-junit dtt.junit.xml --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --printer '\Drupal\Tests\Listeners\HtmlOutputPrinter' ../vendor/weitzman/drupal-test-traits/tests/ExampleSelenium2DriverTest.php"
+  assert_success
 }
 
 teardown() {
   set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
 @test "install from directory" {
   set -eu -o pipefail
-  cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
-  ddev restart
-  ddev exec ls
-  ddev exec "curl -v selenium-chrome:4444/wd/hub/status"
-  echo "Run a FunctionalJavascript test." >&3
-  ddev exec -d /var/www/html/web "../vendor/bin/phpunit -v -c ./core/phpunit.xml.dist ./core/modules/system/tests/src/FunctionalJavascript/FrameworkTest.php"
-  echo "Run a Nightwatch test." >&3
-  ddev exec -d /var/www/html/web/core yarn install
-  ddev exec -d /var/www/html/web/core touch .env
-  ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/jsOnceTest.js
-  echo "Run a Nightwatch test that logs into Drupal." >&3
-  ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/loginTest.js
-  echo "Install Drupal and run a DTT test." >&3
-  ddev exec -d /var/www/html/web "../vendor/bin/drush si -y --account-name=admin --account-pass=password standard"
-  ddev exec -d /var/www/html/web "../vendor/bin/phpunit --log-junit dtt.junit.xml --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --printer '\Drupal\Tests\Listeners\HtmlOutputPrinter' ../vendor/weitzman/drupal-test-traits/tests/ExampleSelenium2DriverTest.php"
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  health_checks
 }


### PR DESCRIPTION
## The Issue

Tests use `ddev get`.

## How This PR Solves The Issue

Updates them to use `ddev add-on get`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

