### PR TITLE
Honor a SKIP_CLEANUP env var in tearDown() in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,9 @@ jobs:
 
     steps:
       - uses: ddev/github-action-add-on-test@v2
+        env:
+          # Ensure that browser_output, junit, Nightwatch report are available as artifacts.
+          SKIP_CLEANUP: "true"
         with:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,6 +26,7 @@ setup() {
 
   export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
   export PROJNAME="test-$(basename "${GITHUB_REPO}")"
+  export SKIP_CLEANUP=1
   mkdir -p ~/tmp
   export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
   export DDEV_NONINTERACTIVE=true
@@ -64,7 +65,6 @@ health_checks() {
 
   run ddev exec -d /var/www/html/web/core touch .env
   assert_success
-  assert_file_exists web/core/.env
 
   run ddev exec -d /var/www/html/web/core yarn test:nightwatch tests/Drupal/Nightwatch/Tests/jsOnceTest.js
   assert_success
@@ -86,7 +86,7 @@ health_checks() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  [ ! -z "${SKIP_CLEANUP}" ] || ( [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR} )
 }
 
 @test "install from directory" {


### PR DESCRIPTION
Set this when running in Github Actions. Now we are saving our Junit, Nightwatch report, and PHPUnit browser output as artifacts.