### PR TITLE
Allow multiple parallel connections to Selenium

### DIFF
--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -17,6 +17,9 @@ services:
       - HTTPS_EXPOSE=7900:7900
       - HTTP_EXPOSE=7910:7900
       - VNC_NO_PASSWORD=1
+        # Enables multiple parallel connections to the Selenium.
+      - SE_NODE_MAX_SESSIONS=12
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true      
     # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",
     # uncomment the following two lines.
     #ports:


### PR DESCRIPTION
## The Issue
By default, only one connection to the Selenium instance inside the container is allowed. Therefore, if a Nightwatch test run process gets a fatal error, you can't run other tests for several seconds or even minutes, which is very inconvenient!

## How This PR Solves The Issue

Enables up to 12 parallel connections to make the new Nightwatch test always find a free connection to start executing.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/Murz-forks/ddev-selenium-standalone-chrome/tarball/allow-multiple-connections
ddev restart
```

## Automated Testing Overview

Seems we have no tests for Selenium and Nightwatch?

## Release/Deployment Notes

Allowed multiple parallel connections to Selenium
