### PR TITLE
Add Chrome logs display on test failure

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -12,6 +12,11 @@
 # For debugging:
 #   bats ./tests/test.bats --show-output-of-passing-tests --verbose-run --print-output-on-failure
 
+bats::on_failure() {
+    echo "Test failed, running debug commands..."
+    ddev logs -s selenium-chrome
+}
+
 setup() {
   set -eu -o pipefail
 
@@ -107,3 +112,4 @@ teardown() {
   assert_success
   health_checks
 }
+


### PR DESCRIPTION
Added a step to show Chrome logs on test failure.

This may help with debugging random test failures such as

<img width="2778" height="1220" alt="image" src="https://github.com/user-attachments/assets/a0a3d853-09fc-4ece-8d7e-fcc8660b5f8f" />
https://github.com/ddev/ddev-selenium-standalone-chrome/actions/runs/19259853228/attempts/1