### PR TITLE
chore(*): run update-checker.sh, constraint v1.24.10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
-  - cron: '25 08 * * *'
+    - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:
@@ -19,9 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Makes it easy to run Functional, FunctionalJavascript, and Nightwatch tests in DDEV. 
+Makes it easy to run Functional, FunctionalJavascript, and Nightwatch tests in DDEV.
 
 This service can be used with any project type. The examples below are Drupal-specific. Contributions for docs and tests that show this service working with other project types are appreciated.
 
@@ -98,7 +98,7 @@ If you use Behat as a test running, adjust your `behat.yml`
 
 ## Contribute
 
-- Anyone is welcome to submit a PR to this repo. See README.md at https://github.com/ddev/ddev-addon-template, the parent of this repo.
+- Anyone is welcome to submit a PR to this repo. See [DDEV Add-on Maintenance Guide](https://ddev.com/blog/ddev-add-on-maintenance-guide/).
 
 ## Credits
 

--- a/install.yaml
+++ b/install.yaml
@@ -4,18 +4,16 @@ project_files:
 - docker-compose.selenium-chrome.yaml
 - config.selenium-standalone-chrome.yaml
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'
 
 post_install_actions:
   - |
-    #ddev-nodisplay
     #ddev-description:Checking docker-compose.selenium-chrome_extras.yaml for changes
     if [ -f docker-compose.selenium-chrome_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.selenium-chrome_extras.yaml; then
       echo "Existing docker-compose.selenium-chrome_extras.yaml does not have #ddev-generated, so can't be updated"
       exit 2
     fi
   - |
-    #ddev-nodisplay
     #ddev-description:Adding all hostnames to the selenium-chrome container to make them available
     cat <<-END >docker-compose.selenium-chrome_extras.yaml
     #ddev-generated
@@ -30,7 +28,6 @@ post_install_actions:
 
 removal_actions:
   - |
-    #ddev-nodisplay
     #ddev-description:Remove docker-compose.selenium-chrome_extras.yaml file
     if [ -f docker-compose.selenium-chrome_extras.yaml ]; then
       if grep -q '#ddev-generated' docker-compose.selenium-chrome_extras.yaml; then


### PR DESCRIPTION
## The Issue

```bash
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

## How This PR Solves The Issue

- Adds version constraint v1.24.10
- Updates add-on files

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/78/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
