### PR TITLE
fix: remove external_links and links, fixes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Functional and FunctionalJavascript tests require the `drupal/core-dev` Composer
 ddev composer require drupal/core-dev
 ```
 
-> [!NOTE]
-> Run `ddev add-on get ddev/ddev-selenium-standalone-chrome` after changes to `name`, `additional_hostnames`, `additional_fqdns`, or `project_tld` in `.ddev/config.yaml` so that `.ddev/docker-compose.selenium-chrome_extras.yaml` is regenerated.
-
 After installation, make sure to commit the `.ddev` directory to version control.
 
 ### Optional steps

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -19,7 +19,7 @@ services:
       - VNC_NO_PASSWORD=1
         # Enables multiple parallel connections to the Selenium.
       - SE_NODE_MAX_SESSIONS=12
-      - SE_NODE_OVERRIDE_MAX_SESSIONS=true      
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
     # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",
     # uncomment the following two lines.
     #ports:
@@ -31,7 +31,3 @@ services:
       # To enable file uploads in E2E tests.
       - ${DDEV_APPROOT}:/var/www/html:r
       - ".:/mnt/ddev_config"
-
-  web:
-    links:
-      - selenium-chrome

--- a/install.yaml
+++ b/install.yaml
@@ -8,31 +8,14 @@ ddev_version_constraint: '>= v1.24.10'
 
 post_install_actions:
   - |
-    #ddev-description:Checking docker-compose.selenium-chrome_extras.yaml for changes
-    if [ -f docker-compose.selenium-chrome_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.selenium-chrome_extras.yaml; then
-      echo "Existing docker-compose.selenium-chrome_extras.yaml does not have #ddev-generated, so can't be updated"
-      exit 2
-    fi
-  - |
-    #ddev-description:Adding all hostnames to the selenium-chrome container to make them available
-    cat <<-END >docker-compose.selenium-chrome_extras.yaml
-    #ddev-generated
-    services:
-      selenium-chrome:
-        external_links:
-        {{- $selenium_chrome_hostnames := splitList "," (env "DDEV_HOSTNAME") -}}
-        {{- range $i, $n := $selenium_chrome_hostnames }}
-          - "ddev-router:{{- replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) -}}"
-        {{- end }}
-    END
-
-removal_actions:
-  - |
-    #ddev-description:Remove docker-compose.selenium-chrome_extras.yaml file
-    if [ -f docker-compose.selenium-chrome_extras.yaml ]; then
-      if grep -q '#ddev-generated' docker-compose.selenium-chrome_extras.yaml; then
-        rm -f docker-compose.selenium-chrome_extras.yaml
+    #ddev-description:Checking for obsolete docker-compose.selenium-chrome_extras.yaml
+    file="$DDEV_APPROOT/.ddev/docker-compose.selenium-chrome_extras.yaml"
+    if [ -f "$file" ]; then
+      if grep -q '#ddev-generated' "$file"; then
+        echo "Removing existing docker-compose.selenium-chrome_extras.yaml, it's not needed anymore."
+        rm -f "$file"
       else
-        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/docker-compose.selenium-chrome_extras.yaml' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+        echo "Unwilling to remove '$file' because it does not have #ddev-generated in it; please remove it manually."
+        exit 1
       fi
     fi


### PR DESCRIPTION
## The Issue

- Fixes #74

## How This PR Solves The Issue

- Removes `.ddev/docker-compose.selenium-chrome_extras.yaml`, it's not needed anymore, DDEV automatically handles hostname resolution in DDEV v1.24.10
- Removes `links` from `.ddev/docker-compose.selenium-chrome.yaml`, it's handled automatically by `docker-compose`
- Updates `README.md`

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/79/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
