### PR TITLE
Revert flaky W3C compatibility feature flag and document Drupal/addon version compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Makes it easy to run Functional, FunctionalJavascript, Nightwatch, Behat and Dru
 
 This service can be used with any project type. The examples below are Drupal-specific. Contributions for docs and tests that show this service working with other project types are appreciated.
 
+## Drupal version compatibility
+
+| Drupal version | Recommended add-on version |
+|---|---|
+| Drupal 11+ | **v2** — `ddev add-on get ddev/ddev-selenium-standalone-chrome` |
+| Drupal 10 | **v1** — `ddev add-on get ddev/ddev-selenium-standalone-chrome --version 1.x` (or pin a specific [v1 tag](https://github.com/ddev/ddev-selenium-standalone-chrome/releases?q=1.x)) |
+
+v2 ships a recent Selenium Grid 4 image and enables W3C compliance mode by default. Drupal 10's WebDriver client is not fully W3C compliant, which causes HTTP 400 errors against newer Grid 4 releases. v1 ships Selenium Grid 4.1.4, which tolerates non-W3C requests and remains compatible with Drupal 10.
+
+> [!NOTE]
+> See [issue #76](https://github.com/ddev/ddev-selenium-standalone-chrome/issues/76) for the full background. If you are on Drupal 11 or later, use v2.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,30 +24,6 @@ ddev composer require drupal/core-dev
 
 After installation, make sure to commit the `.ddev` directory to version control.
 
-### (optional) Configuring W3C compliance mode
-
-By default, WebDriver W3C compliance is enabled (`DRUPAL_TEST_WEBDRIVER_W3C=true`). This controls the `w3c` flag in both `MINK_DRIVER_ARGS_WEBDRIVER` and `DTT_MINK_DRIVER_ARGS`.
-
-If you are running tests on Drupal < 11, you may need to disable W3C mode to avoid WebDriver curl errors (HTTP 400) during test runs. You have a few ways to override it:
-
-**Using `ddev dotenv`** (recommended, keeps it out of version control):
-
-```bash
-ddev dotenv set .ddev/.env.web --drupal-test-webdriver-w3c false
-ddev restart
-```
-
-**Using `.ddev/config.yaml`** (commit this if the whole team needs the same setting):
-
-```yaml
-web_environment:
-  - DRUPAL_TEST_WEBDRIVER_W3C=false
-```
-
-Then run `ddev restart`.
-
-> **Note:** Only disable W3C mode if your tests are failing with HTTP 400 curl errors from the WebDriver endpoint. See [issue #76](https://github.com/ddev/ddev-selenium-standalone-chrome/issues/76) for the original bug report.
-
 ### Optional steps
 
 1. Update the provided `.ddev/config.selenium-standalone-chrome.yaml` as you see fit (and remove the #ddev-generated line). You can also just override lines in your `.ddev/config.yaml`
@@ -68,6 +44,30 @@ Then run `ddev restart`.
   - Drupal Test Traits
     - Ensure you have a working site that has the `weitzman/drupal-test-traits` Composer package.
     - `ddev exec -d /var/www/html/web "../vendor/bin/phpunit --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --printer '\Drupal\Tests\Listeners\HtmlOutputPrinter' ../vendor/weitzman/drupal-test-traits/tests/ExampleSelenium2DriverTest.php"`
+
+### Configuring W3C compliance mode
+
+By default, WebDriver W3C compliance is enabled (`DRUPAL_TEST_WEBDRIVER_W3C=true`). This controls the `w3c` flag in both `MINK_DRIVER_ARGS_WEBDRIVER` and `DTT_MINK_DRIVER_ARGS`.
+
+If you are running tests on Drupal < 11, you may need to disable W3C mode to avoid WebDriver curl errors (HTTP 400) during test runs. You have a few ways to override it:
+
+**Using `ddev dotenv`** (recommended, keeps it out of version control):
+
+```bash
+ddev dotenv set .ddev/.env --drupal-test-webdriver-w3c false
+ddev restart
+```
+
+**Using `.ddev/config.yaml`** (commit this if the whole team needs the same setting):
+
+```yaml
+web_environment:
+  - DRUPAL_TEST_WEBDRIVER_W3C=false
+```
+
+Then run `ddev restart`.
+
+> **Note:** Only disable W3C mode if your tests are failing with HTTP 400 curl errors from the WebDriver endpoint. See [issue #76](https://github.com/ddev/ddev-selenium-standalone-chrome/issues/76) for the original bug report.
 
 ## Watching the tests
 

--- a/README.md
+++ b/README.md
@@ -45,30 +45,6 @@ After installation, make sure to commit the `.ddev` directory to version control
     - Ensure you have a working site that has the `weitzman/drupal-test-traits` Composer package.
     - `ddev exec -d /var/www/html/web "../vendor/bin/phpunit --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --printer '\Drupal\Tests\Listeners\HtmlOutputPrinter' ../vendor/weitzman/drupal-test-traits/tests/ExampleSelenium2DriverTest.php"`
 
-### Configuring W3C compliance mode
-
-By default, WebDriver W3C compliance is enabled (`DRUPAL_TEST_WEBDRIVER_W3C=true`). This controls the `w3c` flag in both `MINK_DRIVER_ARGS_WEBDRIVER` and `DTT_MINK_DRIVER_ARGS`.
-
-If you are running tests on Drupal < 11, you may need to disable W3C mode to avoid WebDriver curl errors (HTTP 400) during test runs. You have a few ways to override it:
-
-**Using `ddev dotenv`** (recommended, keeps it out of version control):
-
-```bash
-ddev dotenv set .ddev/.env --drupal-test-webdriver-w3c false
-ddev restart
-```
-
-**Using `.ddev/config.yaml`** (commit this if the whole team needs the same setting):
-
-```yaml
-web_environment:
-  - DRUPAL_TEST_WEBDRIVER_W3C=false
-```
-
-Then run `ddev restart`.
-
-> **Note:** Only disable W3C mode if your tests are failing with HTTP 400 curl errors from the WebDriver endpoint. See [issue #76](https://github.com/ddev/ddev-selenium-standalone-chrome/issues/76) for the original bug report.
-
 ## Watching the tests
 
 ### The easy way: Use noVNC (built-in)

--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -12,14 +12,14 @@ web_environment:
   # Use disable-dev-shm-usage instead of setting shm_usage
   # https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
   # The format of chromeOptions is defined at https://chromedriver.chromium.org/capabilities
-  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":${DRUPAL_TEST_WEBDRIVER_W3C:-true},\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":true,\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
   # Nightwatch
   - DRUPAL_TEST_BASE_URL=http://web
   - DRUPAL_TEST_DB_URL=mysql://db:db@db/db
   - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
   - DRUPAL_TEST_WEBDRIVER_PORT=4444
   - DRUPAL_TEST_WEBDRIVER_PATH_PREFIX=/wd/hub
-  - DRUPAL_TEST_WEBDRIVER_W3C=${DRUPAL_TEST_WEBDRIVER_W3C:-true}
+  - DRUPAL_TEST_WEBDRIVER_W3C=true
   # --window-size=1920,1080 is needed to fix random timeouts in tests. See: https://community.latenode.com/t/selenium-webdriver-timeout-issue-when-running-in-headless-mode-with-c/21952/4
   - DRUPAL_TEST_WEBDRIVER_CHROME_ARGS=--disable-dev-shm-usage --disable-gpu --headless --dns-prefetch-disable --window-size=1920,1080
   - DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false
@@ -28,6 +28,6 @@ web_environment:
   - DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
   # DTT
   - DTT_BASE_URL=http://web
-  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":${DRUPAL_TEST_WEBDRIVER_W3C:-true},\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":true,\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
   # Behat
   - BEHAT_PARAMS={\"extensions\":{\"Behat\\\\MinkExtension\":{\"base_url\":\"http://web\",\"default_session\":\"selenium2\",\"javascript_session\":\"selenium2\",\"sessions\":{\"selenium2\":{\"selenium2\":{\"browser\":\"chrome\",\"wd_host\":\"http://selenium-chrome:4444/wd/hub\",\"capabilities\":{\"browserName\":\"chrome\",\"extra_capabilities\":{\"goog:chromeOptions\":{\"w3c\":${DRUPAL_TEST_WEBDRIVER_W3C:-true},\"args\":[\"--headless\",\"--disable-gpu\",\"--no-sandbox\",\"--disable-dev-shm-usage\",\"--dns-prefetch-disable\",\"--window-size=1920,1080\"]}}}}}}},\"Drupal\\\\DrupalExtension\":{\"blackbox\":null,\"api_driver\":\"drupal\",\"drush\":{\"root\":\"/var/www/html/web\"},\"drupal\":{\"drupal_root\":\"/var/www/html/web\"}}}}


### PR DESCRIPTION
## The Issue

- Fixes #76

## How This PR Solves The Issue

Documents that addon v2 is not compatible with Drupal 10.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
