### PR TITLE
Docs v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 | Drupal version | Recommended add-on version |
 |---|---|
-| Drupal 11+ | **v2** — `ddev add-on get ddev/ddev-selenium-standalone-chrome` |
 | Drupal 10 | **v1** — `ddev add-on get ddev/ddev-selenium-standalone-chrome --version 1.x` (or pin a specific [v1 tag](https://github.com/ddev/ddev-selenium-standalone-chrome/releases?q=1.x)) |
+| Drupal 11+ | **v2** — `ddev add-on get ddev/ddev-selenium-standalone-chrome` |
 
 v2 ships a recent Selenium Grid 4 image and enables W3C compliance mode by default. Drupal 10's WebDriver client is not fully W3C compliant, which causes HTTP 400 errors against newer Grid 4 releases. v1 ships Selenium Grid 4.1.4, which tolerates non-W3C requests and remains compatible with Drupal 10.
 
@@ -26,7 +26,7 @@ v2 ships a recent Selenium Grid 4 image and enables W3C compliance mode by defau
 ## Installation
 
 ```bash
-ddev add-on get ddev/ddev-selenium-standalone-chrome
+ddev add-on get ddev/ddev-selenium-standalone-chrome --version 1.x # RECOMMENDED: Pin a specific v1 tag: https://github.com/ddev/ddev-selenium-standalone-chrome/releases?q=1.x
 ddev restart
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Makes it easy to run Functional, FunctionalJavascript, Nightwatch, Behat and Dru
 
 This service can be used with any project type. The examples below are Drupal-specific. Contributions for docs and tests that show this service working with other project types are appreciated.
 
+## Drupal version compatibility
+
+| Drupal version | Recommended add-on version |
+|---|---|
+| Drupal 11+ | **v2** — `ddev add-on get ddev/ddev-selenium-standalone-chrome` |
+| Drupal 10 | **v1** — `ddev add-on get ddev/ddev-selenium-standalone-chrome --version 1.x` (or pin a specific [v1 tag](https://github.com/ddev/ddev-selenium-standalone-chrome/releases?q=1.x)) |
+
+v2 ships a recent Selenium Grid 4 image and enables W3C compliance mode by default. Drupal 10's WebDriver client is not fully W3C compliant, which causes HTTP 400 errors against newer Grid 4 releases. v1 ships Selenium Grid 4.1.4, which tolerates non-W3C requests and remains compatible with Drupal 10.
+
+> [!NOTE]
+> See [issue #76](https://github.com/ddev/ddev-selenium-standalone-chrome/issues/76) for the full background. If you are on Drupal 11 or later, use v2.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Backport of #90.

## The Issue

- Fixes #76  

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Documents that addon v2 is not compatible with Drupal 10.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
