### PR TITLE
ci(test): add `--no-security-blocking` to `composer require`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bats,sh,yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 tests/ export-ignore
 .github/ export-ignore
 .gitattributes export-ignore
+.editorconfig export-ignore

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -31,16 +31,19 @@ setup() {
 
   export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
   export PROJNAME="test-$(basename "${GITHUB_REPO}")"
-  mkdir -p ~/tmp
-  export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
+  mkdir -p "${HOME}/tmp"
+  export TESTDIR="$(mktemp -d "${HOME}/tmp/${PROJNAME}.XXXXXX")"
   export DDEV_NONINTERACTIVE=true
   export DDEV_NO_INSTRUMENTATION=true
   ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
   cd "${TESTDIR}"
 
-  composer -n --no-install create-project 'drupal/recommended-project:^11' .
-  composer -n config --no-plugins allow-plugins true
-  composer -n require 'drupal/core-dev:^11' 'drush/drush:^13' 'weitzman/drupal-test-traits:^2' 'drupal/drupal-extension:^5.4' -W
+  run composer -n --no-install create-project 'drupal/recommended-project:^11' .
+  assert_success
+  run composer -n config --no-plugins allow-plugins true
+  assert_success
+  run composer -n require 'drupal/core-dev:^11' 'drush/drush:^13' 'weitzman/drupal-test-traits:^2' 'drupal/drupal-extension:^5.4' -W --no-security-blocking
+  assert_success
 
   cp "${DIR}/tests/fixtures/behat/behat.yml" .
   mkdir -p behat


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev-selenium-standalone-chrome/actions/runs/26154269757/job/76957047823

```
not ok 1 install from directory
# (from function `setup' in test file tests/test.bats, line 43)
#   `composer -n require 'drupal/core-dev:^11' 'drush/drush:^13' 'weitzman/drupal-test-traits:^2' 'drupal/drupal-extension:^5.4' -W' failed with status 2
# Creating a "drupal/recommended-project:^11" project at "./"
# Installing drupal/recommended-project (11.3.9)
#   - Downloading drupal/recommended-project (11.3.9)
#   - Installing drupal/recommended-project (11.3.9): Extracting archive
# Created project in /home/runner/tmp/test-ddev-selenium-standalone-chrome.ABGhPj/.
# ./composer.json has been updated
# Running composer update drupal/core-dev drush/drush weitzman/drupal-test-traits drupal/drupal-extension --with-all-dependencies
# Loading composer repositories with package information
# Updating dependencies
# Your requirements could not be resolved to an installable set of packages.
#
#   Problem 1
#     - drupal/core-recommended is locked to version 11.3.9 and an update of this package was not requested.
#     - drupal/core-recommended 11.3.9 requires twig/twig ~v3.22.0 -> found twig/twig[v3.22.0, v3.22.1, v3.22.2] but these were not loaded, because they are affected by security advisories ("PKSA-5k7f-wvjj-jrgw", "PKSA-sjvz-tbbr-vwth", "PKSA-h8hf-ytnd-5t9q", "PKSA-wwb1-81rc-pd65", "PKSA-kvv6-36cr-fkzb", "PKSA-n14z-jjjg-g8vd", "PKSA-3mcc-k66d-pydb", "PKSA-gw7n-z4yx-7xjt", "PKSA-dpx1-78wg-1kqs", "PKSA-21g2-dzjv-sky5"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

## How This PR Solves The Issue

This is annoying, it's better to use this in tests:

```diff
-composer require
+composer require --no-security-blocking
```

Note that `ddev composer create-project` doesn't have such a problem, but we can't use `ddev composer` here without moving the code logic.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/92/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
