### PR TITLE
ci(test): add `--no-security-blocking` to `composer require`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bats,sh,yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore
+.editorconfig export-ignore

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -31,16 +31,19 @@ setup() {
 
   export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
   export PROJNAME="test-$(basename "${GITHUB_REPO}")"
-  mkdir -p ~/tmp
-  export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
+  mkdir -p "${HOME}/tmp"
+  export TESTDIR="$(mktemp -d "${HOME}/tmp/${PROJNAME}.XXXXXX")"
   export DDEV_NONINTERACTIVE=true
   export DDEV_NO_INSTRUMENTATION=true
   ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
   cd "${TESTDIR}"
 
-  composer -n --no-install create-project 'drupal/recommended-project:^10.5' .
-  composer -n config --no-plugins allow-plugins true
-  composer -n require 'drupal/core-dev:^10.5' 'drush/drush:^13' 'weitzman/drupal-test-traits:^2' 'drupal/drupal-extension:^5.4' -W
+  run composer -n --no-install create-project 'drupal/recommended-project:^10.5' .
+  assert_success
+  run composer -n config --no-plugins allow-plugins true
+  assert_success
+  run composer -n require 'drupal/core-dev:^10.5' 'drush/drush:^13' 'weitzman/drupal-test-traits:^2' 'drupal/drupal-extension:^5.4' -W --no-security-blocking
+  assert_success
 
   cp "${DIR}/tests/fixtures/behat/behat.yml" .
   mkdir -p behat


### PR DESCRIPTION
## The Issue

- Backport of #92

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/93/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
