### PR TITLE
Trust the DDEV mkcert CA so tests can browse the project over HTTPS

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -38,6 +38,7 @@ hooks:
     # HTTPS do not land on a certificate warning page instead of the site.
     - exec: |
         if [ -f /mnt/ddev-global-cache/mkcert/rootCA.pem ]; then
+          certutil -d sql:/home/seluser/.pki/nssdb -D -n ddev-mkcert 2>/dev/null || true
           certutil -d sql:/home/seluser/.pki/nssdb -A -t "C,," -n ddev-mkcert -i /mnt/ddev-global-cache/mkcert/rootCA.pem
         fi
       service: selenium-chrome

--- a/config.selenium-standalone-chrome.yaml
+++ b/config.selenium-standalone-chrome.yaml
@@ -31,3 +31,13 @@ web_environment:
   - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":true,\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
   # Behat
   - BEHAT_PARAMS={\"extensions\":{\"Behat\\\\MinkExtension\":{\"base_url\":\"http://web\",\"default_session\":\"selenium2\",\"javascript_session\":\"selenium2\",\"sessions\":{\"selenium2\":{\"selenium2\":{\"browser\":\"chrome\",\"wd_host\":\"http://selenium-chrome:4444/wd/hub\",\"capabilities\":{\"browserName\":\"chrome\",\"extra_capabilities\":{\"goog:chromeOptions\":{\"w3c\":${DRUPAL_TEST_WEBDRIVER_W3C:-true},\"args\":[\"--headless\",\"--disable-gpu\",\"--no-sandbox\",\"--disable-dev-shm-usage\",\"--dns-prefetch-disable\",\"--window-size=1920,1080\"]}}}}}}},\"Drupal\\\\DrupalExtension\":{\"blackbox\":null,\"api_driver\":\"drupal\",\"drush\":{\"root\":\"/var/www/html/web\"},\"drupal\":{\"drupal_root\":\"/var/www/html/web\"}}}}
+
+hooks:
+  post-start:
+    # Trust the DDEV mkcert root CA, so tests that browse the project over
+    # HTTPS do not land on a certificate warning page instead of the site.
+    - exec: |
+        if [ -f /mnt/ddev-global-cache/mkcert/rootCA.pem ]; then
+          certutil -d sql:/home/seluser/.pki/nssdb -A -t "C,," -n ddev-mkcert -i /mnt/ddev-global-cache/mkcert/rootCA.pem
+        fi
+      service: selenium-chrome

--- a/docker-compose.selenium-chrome.yaml
+++ b/docker-compose.selenium-chrome.yaml
@@ -31,3 +31,6 @@ services:
       # To enable file uploads in E2E tests.
       - "../:/var/www/html"
       - ".:/mnt/ddev_config"
+      # Provides mkcert/rootCA.pem to the post-start hook in
+      # config.selenium-standalone-chrome.yaml.
+      - "ddev-global-cache:/mnt/ddev-global-cache"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -64,6 +64,12 @@ health_checks() {
   assert_success
   assert_output --partial "Selenium Grid ready."
 
+  echo "Ensure the DDEV mkcert CA is trusted by the browser." >&3
+
+  run ddev exec -s selenium-chrome certutil -d sql:/home/seluser/.pki/nssdb -L
+  assert_success
+  assert_output --partial "ddev-mkcert"
+
   echo "Run a FunctionalJavascript test." >&3
 
   run ddev exec -d /var/www/html/web "../vendor/bin/phpunit -c ./core/phpunit.xml.dist ./core/modules/system/tests/src/FunctionalJavascript/FrameworkTest.php"


### PR DESCRIPTION
## The Issue

- Fixes #94

The test runners default to http://web, so the browser never needs to trust a certificate. Projects that have to browse the real project URL, for example a multisite where the hostname selects the site, land on a certificate warning page instead of the site.

## How This PR Solves The Issue

Mount ddev-global-cache, where DDEV keeps mkcert/rootCA.pem, and import it into the browser's NSS database on start. Projects staying on http://web are unaffected, they just get one more trusted CA in the test browser.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-selenium-standalone-chrome/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

Check that the CA was imported:

```bash
ddev exec -s selenium-chrome certutil -d sql:/home/seluser/.pki/nssdb -L
```

`ddev-mkcert` should be listed next to the image's own `SeleniumHQ_tls.crt`.

To see the actual effect, point a browser test at the project URL rather than http://web: before this change it lands on the `Privacy error` page instead of the site.

## Automated Testing Overview

Added an assertion to `health_checks()` in `tests/test.bats` that lists the browser's NSS database and expects `ddev-mkcert`. The existing tests all browse http://web, so none of them would notice this breaking.

## Release/Deployment Notes

No breaking changes. The hook is a no-op when `mkcert/rootCA.pem` is absent, for example in CI or when DDEV is configured without TLS.
